### PR TITLE
make size output easier to read via bytes

### DIFF
--- a/lib/cli-views.js
+++ b/lib/cli-views.js
@@ -1,10 +1,13 @@
 const c = require('chalk');
-const _ = require('lodash')
+const _ = require('lodash');
+const bytes = require('bytes');
 
 const syntheticView = stat => {
+    const size = bytes(stat.size);
+    const gzip = bytes(stat.gzip);
     return `${c.bold.underline(stat.name)} (${c.grey.dim(stat.version)
-    }) has ${c.blue.bold(stat.dependencyCount)} dependencies for a weight of ${c.cyan.bold(stat.size)
-    }B (${c.dim.bold(stat.gzip)}B gzipped)`
+    }) has ${c.blue.bold(stat.dependencyCount)} dependencies for a weight of ${c.cyan.bold(size)
+    } (${c.dim.bold(gzip)} gzipped)`
 }
 // TODO: later dynamic color + kilo printing + plural
 const jsonView = JSON.stringify;
@@ -27,7 +30,6 @@ const getView = (argv = {}) => {
 
 module.exports.syntheticView = syntheticView;
 module.exports.jsonView = jsonView;
-module.exports.getView = getView;
 module.exports.sizeView = sizeView;
 module.exports.gzipsizeView = gzipsizeView;
 module.exports.dependenciesView = dependenciesView;

--- a/lib/npm-utils.js
+++ b/lib/npm-utils.js
@@ -6,7 +6,7 @@ const getVersionList = name => {
     return Promise.fromCallback(callback =>
         exec(`npm show ${name} versions --json`, (err, stdout, stderr) => {
             if (err) {
-                if (/Registry returned 404 for GET on/.test(stderr)) {
+                if (/Registry returned 404 for GET on/.test(stderr) || /404 Not found/.test(stderr)) {
                     callback(new Error(`Unknown Package ${name}`));
                 } else {
                     callback(err);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/AdrieanKhisbe/bundle-phobia-cli#readme",
   "dependencies": {
     "bluebird": "^3.5.0",
+    "bytes": "^3.0.0",
     "chalk": "^2.1.0",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.3",

--- a/test/cli-views.test.js
+++ b/test/cli-views.test.js
@@ -6,7 +6,7 @@ describe('syntheticView', () => {
 
     it('basic lodash stats', () => {
         const lodashView = stripAnsi(syntheticView(lodashStats));
-        expect(lodashView).toEqual('lodash (4.17.4) has 0 dependencies for a weight of 70870B (24666B gzipped)');
+        expect(lodashView).toEqual('lodash (4.17.4) has 0 dependencies for a weight of 69.21KB (24.09KB gzipped)');
     });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,6 +351,10 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bytes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"


### PR DESCRIPTION
Fixes #2.

I also fixed an unrelated bug, as it seems that npm's 404 output has changed recently.