### PR TITLE
Adds the standard X-Bundlephobia-User header

### DIFF
--- a/lib/fetch-package-stats.js
+++ b/lib/fetch-package-stats.js
@@ -6,7 +6,7 @@ const {getVersionList} = require('./npm-utils');
 const fetchPackageStats = name => {
     if (!name) return Promise.reject(new Error('Empty name given as argument'))
     return fetch(`https://bundlephobia.com/api/size?package=${name}`,
-        {headers: {'User-Agent': 'bundle-phobia-cli'}})
+        {headers: {'User-Agent': 'bundle-phobia-cli', 'X-Bundlephobia-User': 'bundle-phobia-cli'}})
         .then(res => res.json())
         .then(json => {
             if (json.error) throw new Error(json.error.message)


### PR DESCRIPTION
We've standardised on this header for API usage. In the absence of an API key, this header is required to recognise the source of traffic. It would be great if we can put this.