### PR TITLE
Add support for scoped packages

### DIFF
--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -24,7 +24,11 @@ const getVersionList = name => {
 const shouldResolve = pkg => /.*@([~^]|.*x)/.test(pkg);
 
 const resolveVersionRange = pkg => {
-  const [packageName, version] = pkg.split('@');
+  // unfortunately no named capture groups in Node 6..
+  const match = pkg.match(/^(@?[^@]+)(?:@(.*?))?$/);
+  if (!match) return Promise.reject(new Error(`Unable to parse package name ${pkg}`));
+  const packageName = match[1];
+  const version = match[2];
   if (!shouldResolve(pkg)) return getVersionList(packageName).return(pkg);
   return Promise.fromCallback(cb => {
     resolver({[packageName]: version}, function(err, result) {

--- a/test/npm-utils.test.js
+++ b/test/npm-utils.test.js
@@ -24,6 +24,12 @@ describe('getVersionList', () => {
 });
 
 describe('resolveVersionRange', () => {
+  it('rejects when package name is unparseable', () => {
+    return resolveVersionRange('@@foo@zzz').catch(err => {
+      return expect(err.message).toEqual('Unable to parse package name @@foo@zzz');
+    });
+  });
+
   it('simple package with no version', () => {
     return resolveVersionRange('whatever').then(version => {
       return expect(version).toEqual('whatever');
@@ -34,7 +40,7 @@ describe('resolveVersionRange', () => {
       return expect(version).toEqual('whatever@2.2.2');
     });
   });
-  it('simple package wich does not exist', () => {
+  it('simple package which does not exist', () => {
     return resolveVersionRange('publish-me-to-break-the-test').catch(err => {
       return expect(err.message).toEqual("The package you were looking for doesn't exist.");
     });
@@ -48,6 +54,32 @@ describe('resolveVersionRange', () => {
   it('simple package with version to be resolved', () => {
     return resolveVersionRange('lodash@~4.16.4').then(version => {
       return expect(version).toEqual('lodash@4.16.6');
+    });
+  });
+
+  it('scoped package with no version', () => {
+    return resolveVersionRange('@atlaskit/button').then(version => {
+      return expect(version).toEqual('@atlaskit/button');
+    });
+  });
+  it('scoped package with version not to be resolved', () => {
+    return resolveVersionRange('@atlaskit/button@10.1.2').then(version => {
+      return expect(version).toEqual('@atlaskit/button@10.1.2');
+    });
+  });
+  it('scoped package which does not exist', () => {
+    return resolveVersionRange('@atlaskit/publish-me-to-break-the-test').catch(err => {
+      return expect(err.message).toEqual("The package you were looking for doesn't exist.");
+    });
+  });
+  it('scoped package with version to be resolved but cant', () => {
+    return resolveVersionRange('@atlaskit/button@~2.2.2').catch(err => {
+      return expect(err.message).toEqual("Specified version range '~2.2.2' is not resolvable");
+    });
+  });
+  it('scoped package with version to be resolved', () => {
+    return resolveVersionRange('@atlaskit/button@^1.0.0').then(version => {
+      return expect(version).toEqual('@atlaskit/button@1.1.4');
     });
   });
 });


### PR DESCRIPTION
In `npm-utils` the package name and version was derived from the input by splitting on `@` - this wasn't compatible with scoped packages (e.g. `@atlaskit/button@1.0.0`).

I would've used named capture groups for this, but as far as I can see from the Travis config you're still testing against Node 6 which doesn't support these, so a slightly more manual approach has been taken.