### PR TITLE
Fix bug with package with dot in name needing resolving

### DIFF
--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -34,7 +34,7 @@ const resolveVersionRange = async pkg => {
     resolver({[packageName]: version}, function(err, result) {
       /* istanbul ignore if*/
       if (err) return reject(err);
-      if (!_.has(`dependencies.${packageName}`, result))
+      if (!_.has(['dependencies', packageName], result))
         return reject(new Error(`Specified version range '${version}' is not resolvable`));
       return resolve(`${packageName}@${result.dependencies[packageName].version}`);
     });

--- a/test/integration/core.integration.test.js
+++ b/test/integration/core.integration.test.js
@@ -46,6 +46,15 @@ test('prevent to fetch list of package with range', async t => {
   }
 });
 
+test('handle package with dot, using a caret version lock', async t => {
+  const stream = fakeStream();
+  await main({argv: {_: ['ahoy.js@^0.3.5']}, stream});
+
+  const [firstLine, secondLine] = stream.getContent().split('\n');
+  t.is(firstLine, '- Fetching stats for package ahoy.js@^0.3.5');
+  t.true(secondLine.startsWith('ℹ ahoy.js (0.', `Unexpected resolve entry: '${secondLine}'`));
+});
+
 test('fetch a package that does not exist at all', async t => {
   const stream = fakeStream();
   await t.throwsAsync(


### PR DESCRIPTION
Fix issue pointed by @bbugh in #35

dots in package name are interpreted by `lodash.has` as path separator, and so package is not found in dependencies sections

This PR add an anti regression test and use array for path specification in `_.has` rather that interpolated string path.