### PR TITLE
Bugfix on Windows 10: command not working

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -111,7 +111,7 @@ const main = async ({
   const pluralSuffix = _.size(packages) > 1 ? 's' : '';
 
   const performInstall = () => {
-    const res = execFile(`npm`, installCommandArgs(argv));
+    const res = execFile(`npm`, installCommandArgs(argv), {shell: true});
     if (res.code !== 0) throw new Error(`npm install returned with status code ${res.code}`);
   };
   const predicate = getSizePredicate(argv, defaultMaxSize, currentPkg);

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -18,7 +18,7 @@ const getVersionList = name => {
   );
 };
 
-const getNpmCommand = () => process.platform.startsWith('win') ? 'npm.cmd' : 'npm';
+const getNpmCommand = () => (process.platform.startsWith('win') ? 'npm.cmd' : 'npm');
 
 const shouldResolve = pkg => /.*@([\^~]|.*x)/.test(pkg);
 

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -5,7 +5,7 @@ const _ = require('lodash/fp');
 const getVersionList = name => {
   if (!name) return Promise.reject(new Error('Empty name given as argument'));
   return new Promise((resolve, reject) =>
-    execFile(getNpmCommand(), ['show', name, 'versions', '--json'], {shell: true}, (err, stdout, stderr) => {
+    execFile('npm', ['show', name, 'versions', '--json'], {shell: true}, (err, stdout, stderr) => {
       if (err) {
         return reject(
           /Registry returned 404 for GET on|404 Not found|code E404/.test(stderr)

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -5,7 +5,7 @@ const _ = require('lodash/fp');
 const getVersionList = name => {
   if (!name) return Promise.reject(new Error('Empty name given as argument'));
   return new Promise((resolve, reject) =>
-    execFile(getCommand( ), ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
+    execFile(getNpmCommand( ), ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
       if (err) {
         return reject(
           /Registry returned 404 for GET on|404 Not found|code E404/.test(stderr)

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -5,7 +5,7 @@ const _ = require('lodash/fp');
 const getVersionList = name => {
   if (!name) return Promise.reject(new Error('Empty name given as argument'));
   return new Promise((resolve, reject) =>
-    execFile(getNpmCommand( ), ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
+    execFile(getNpmCommand(), ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
       if (err) {
         return reject(
           /Registry returned 404 for GET on|404 Not found|code E404/.test(stderr)
@@ -18,7 +18,7 @@ const getVersionList = name => {
   );
 };
 
-const getNpmCommand = () => /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+const getNpmCommand = () => process.platform.startsWith('win') ? 'npm.cmd' : 'npm';
 
 const shouldResolve = pkg => /.*@([\^~]|.*x)/.test(pkg);
 

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -5,7 +5,7 @@ const _ = require('lodash/fp');
 const getVersionList = name => {
   if (!name) return Promise.reject(new Error('Empty name given as argument'));
   return new Promise((resolve, reject) =>
-    execFile(`npm`, ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
+    execFile(getCommand( ), ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
       if (err) {
         return reject(
           /Registry returned 404 for GET on|404 Not found|code E404/.test(stderr)
@@ -17,6 +17,8 @@ const getVersionList = name => {
     })
   );
 };
+
+const getNpmCommand = () => /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
 
 const shouldResolve = pkg => /.*@([\^~]|.*x)/.test(pkg);
 

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -5,7 +5,7 @@ const _ = require('lodash/fp');
 const getVersionList = name => {
   if (!name) return Promise.reject(new Error('Empty name given as argument'));
   return new Promise((resolve, reject) =>
-    execFile(getNpmCommand(), ['show', name, 'versions', '--json'], (err, stdout, stderr) => {
+    execFile(getNpmCommand(), ['show', name, 'versions', '--json'], {shell: true}, (err, stdout, stderr) => {
       if (err) {
         return reject(
           /Registry returned 404 for GET on|404 Not found|code E404/.test(stderr)
@@ -17,8 +17,6 @@ const getVersionList = name => {
     })
   );
 };
-
-const getNpmCommand = () => (process.platform.startsWith('win') ? 'npm.cmd' : 'npm');
 
 const shouldResolve = pkg => /.*@([\^~]|.*x)/.test(pkg);
 


### PR DESCRIPTION
This pull requests addresses a bug I ran into on Windows 10.
Every audit of a package fails with the error `spawn npm ENOENT`.
This is due to (at least my) Windows requiring `npm.cmd` instead of `npm` to function.
This pr replaces the hardcoded `npm` with a conditional string based on the OS.