### PR TITLE
Fixed bundle-phobia-install not working

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -114,6 +114,7 @@ const main = async ({
     new Promise((resolve, reject) =>
       execFile(`npm`, installCommandArgs(argv), {shell: true}, err => {
         if (err) return reject(new Error(`npm install returned with status code ${err.code}`));
+        resolve();
       })
     );
   const predicate = getSizePredicate(argv, defaultMaxSize, currentPkg);

--- a/src/install.js
+++ b/src/install.js
@@ -110,10 +110,12 @@ const main = async ({
   if (_.isEmpty(packages)) throw new Error('No packages to install was given');
   const pluralSuffix = _.size(packages) > 1 ? 's' : '';
 
-  const performInstall = () => {
-    const res = execFile(`npm`, installCommandArgs(argv), {shell: true});
-    if (res.code !== 0) throw new Error(`npm install returned with status code ${res.code}`);
-  };
+  const performInstall = () =>
+    new Promise((resolve, reject) =>
+      execFile(`npm`, installCommandArgs(argv), {shell: true}, err => {
+        if (err) return reject(new Error(`npm install returned with status code ${err.code}`));
+      })
+    );
   const predicate = getSizePredicate(argv, defaultMaxSize, currentPkg);
   const globalPredicate = getGlobalSizePredicate(argv, currentPkg);
 

--- a/test/integration/install.integration.test.js
+++ b/test/integration/install.integration.test.js
@@ -1,21 +1,21 @@
 const test = require('ava');
 const {main} = require('../../src/install');
-const {fakeStream, fakeExecFile, fakePkg, fakePrompt} = require('./utils');
+const {fakeStream, fakeSpawn, fakePkg, fakePrompt} = require('./utils');
 
 const defaultMaxSize = 10000;
 
 test('install just a single package and fail', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
   try {
     await main({
       argv: {_: ['lodash@4.12.0']},
       stream,
-      execFile,
+      spawn,
       defaultMaxSize,
       readPkg: fakePkg
     });
-    throw new Error('Did not fail as execFileted');
+    throw new Error('Did not fail as spawned');
   } catch (err) {
     t.is(err.message, 'Install was canceled.');
     t.is(
@@ -33,12 +33,12 @@ test('install just a single package and fail', async t => {
 
 test('install just a single package and succeed', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
   //
   await main({
     argv: {_: ['bytes@3.0.0']},
     stream,
-    execFile,
+    spawn,
     defaultMaxSize,
     readPkg: fakePkg
   });
@@ -51,17 +51,17 @@ test('install just a single package and succeed', async t => {
 ℹ Proceed to installation of package bytes@3.0.0
 `
   );
-  t.is(execFile.invokedCmd, 'npm');
-  t.deepEqual(execFile.invokedArgs, ['install', 'bytes@3.0.0']);
+  t.is(spawn.invokedCmd, 'npm');
+  t.deepEqual(spawn.invokedArgs, ['install', 'bytes@3.0.0']);
 });
 
 test('install just a single package and just warn', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
   await main({
     argv: {_: ['lodash@4.12.0'], w: true, warn: true, 'save-dev': true},
     stream,
-    execFile,
+    spawn,
     defaultMaxSize,
     readPkg: fakePkg
   });
@@ -75,18 +75,18 @@ test('install just a single package and just warn', async t => {
 ⚠ lodash@4.12.0: size over threshold (63.65KB > 9.77KB)
 `
   );
-  t.is(execFile.invokedCmd, 'npm');
-  t.deepEqual(execFile.invokedArgs, ['install', 'lodash@4.12.0', '--save-dev']);
+  t.is(spawn.invokedCmd, 'npm');
+  t.deepEqual(spawn.invokedArgs, ['install', 'lodash@4.12.0', '--save-dev']);
 });
 
 test('ask to install a package and accept', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
   const prompt = fakePrompt();
   await main({
     argv: {_: ['lodash@4.12.0'], i: true, interactive: true},
     stream,
-    execFile,
+    spawn,
     prompt,
     defaultMaxSize,
     readPkg: fakePkg
@@ -101,17 +101,17 @@ test('ask to install a package and accept', async t => {
 ✔ Proceeding with installation as you requested
 `
   );
-  t.is(execFile.invokedCmd, 'npm');
-  t.deepEqual(execFile.invokedArgs, ['install', 'lodash@4.12.0']);
+  t.is(spawn.invokedCmd, 'npm');
+  t.deepEqual(spawn.invokedArgs, ['install', 'lodash@4.12.0']);
 });
 test('ask to install a package and deny', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
   const prompt = fakePrompt(false);
   await main({
     argv: {_: ['lodash@4.12.0'], i: true, interactive: true},
     stream,
-    execFile,
+    spawn,
     prompt,
     defaultMaxSize,
     readPkg: fakePkg
@@ -127,17 +127,17 @@ test('ask to install a package and deny', async t => {
 ✖ Installation is canceled on your demand
 `
   );
-  t.is(execFile.invokedCmd, undefined);
+  t.is(spawn.invokedCmd, undefined);
 });
 
 test('try to install package that does not exist', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
   try {
     await main({
       argv: {_: ['no-sorry-but-i-do-not-exist']},
       stream,
-      execFile,
+      spawn,
       defaultMaxSize,
       readPkg: fakePkg
     });
@@ -153,12 +153,12 @@ test('try to install package that does not exist', async t => {
 
 test('install just a single package on empty package with global config and succeed', async t => {
   const stream = fakeStream();
-  const execFile = fakeExecFile();
+  const spawn = fakeSpawn();
 
   await main({
     argv: {_: ['bytes@3.0.0']},
     stream,
-    execFile,
+    spawn,
     defaultMaxSize,
     readPkg: () => ({
       dependencies: {},
@@ -177,6 +177,6 @@ test('install just a single package on empty package with global config and succ
 ℹ Proceed to installation of package bytes@3.0.0
 `
   );
-  t.is(execFile.invokedCmd, 'npm');
-  t.deepEqual(execFile.invokedArgs, ['install', 'bytes@3.0.0']);
+  t.is(spawn.invokedCmd, 'npm');
+  t.deepEqual(spawn.invokedArgs, ['install', 'bytes@3.0.0']);
 });

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -17,9 +17,7 @@ const fakeExecFile = (statusCode = 0) => {
   const execFile = (cmd, args) => {
     runCommand = cmd;
     runArgs = args;
-    return statusCode === 0
-      ? Promise.resolve()
-      : Promise.reject(new Error(`npm install returned with status code ${statusCode}`));
+    return {code: statusCode};
   };
   Object.defineProperties(execFile, {
     invokedCmd: {get: () => runCommand},

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -12,19 +12,19 @@ const fakeStream = () => {
   };
 };
 
-const fakeExecFile = (statusCode = 0, stdout = '', stderr = '') => {
+const fakeSpawn = (statusCode = 0, stdout = '', stderr = '') => {
   let runCommand, runArgs;
-  const execFile = (cmd, args, options, callback) => {
+  const spawn = (cmd, args, options, callback) => {
     runCommand = cmd;
     runArgs = args;
     const errorObject = statusCode !== 0 ? {code: statusCode} : null;
     callback(errorObject, stdout, stderr);
   };
-  Object.defineProperties(execFile, {
+  Object.defineProperties(spawn, {
     invokedCmd: {get: () => runCommand},
     invokedArgs: {get: () => runArgs}
   });
-  return execFile;
+  return spawn;
 };
 const fakePkg = () => ({dependencies: {ora: '^3.0.0'}});
 
@@ -38,4 +38,4 @@ const fakePrompt = (result = true) => {
   return prompt;
 };
 
-module.exports = {fakeStream, fakeExecFile, fakePkg, fakePrompt};
+module.exports = {fakeStream, fakeSpawn, fakePkg, fakePrompt};

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -17,7 +17,9 @@ const fakeExecFile = (statusCode = 0) => {
   const execFile = (cmd, args) => {
     runCommand = cmd;
     runArgs = args;
-    return {code: statusCode};
+    return statusCode === 0
+      ? Promise.resolve()
+      : Promise.reject(new Error(`npm install returned with status code ${statusCode}`));
   };
   Object.defineProperties(execFile, {
     invokedCmd: {get: () => runCommand},

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -12,12 +12,14 @@ const fakeStream = () => {
   };
 };
 
-const fakeExecFile = (statusCode = 0) => {
+const fakeExecFile = (statusCode = 0, stdout = '', stderr = '') => {
   let runCommand, runArgs;
-  const execFile = (cmd, args) => {
+  const execFile = (cmd, args, options, callback) => {
     runCommand = cmd;
     runArgs = args;
-    return {code: statusCode};
+    const errorObject = statusCode !== 0 ? {code: statusCode} : null;
+    callback(errorObject, stdout, stderr);
+    return {};
   };
   Object.defineProperties(execFile, {
     invokedCmd: {get: () => runCommand},

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -19,7 +19,6 @@ const fakeExecFile = (statusCode = 0, stdout = '', stderr = '') => {
     runArgs = args;
     const errorObject = statusCode !== 0 ? {code: statusCode} : null;
     callback(errorObject, stdout, stderr);
-    return {};
   };
   Object.defineProperties(execFile, {
     invokedCmd: {get: () => runCommand},


### PR DESCRIPTION
The `bundle-phobia-install` command didn't work for me, regardless of #37.
Every attempt failed with the error `npm install returned with status code undefined`
To fix it, I encapsulated the actual `execFile` within `const performInstall` with a Promise.

Reasons to believe that should be the case:

1. Every invocation of the function is awaited
2. The same function in `npm-utils.js` returns a Promise
3. `execFile` is asynchronous, so acting on the direct result instead of in a callback does not guarantee the process has been finished
4. The current error check relies on `res.code` where `res` is the result of `execFile`. The resulting [`ChildProcess`](https://nodejs.org/api/child_process.html#child_process_class_childprocess) does in fact not contain a property called `code` (hence the "status code undefined")

The reason this has not been identified in integration tests is that the test in question mocks the `execFile` (incorrectly: it contains a property `code` which the documented `ChildProcess` doesn't), so it never has to deal with a process error. I would propose a fix for this as well, but I do not feel confident enough in your testing stack so I'll leave that decision to the author 🤕🤷‍♂️

_(If all is well you should be able to commit to my branch)_